### PR TITLE
Start handle IDs at 1 instead of 0

### DIFF
--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -59,6 +59,7 @@ func New() *Exchange {
 		topicForHandle: make(map[Handle]Topic),
 		mu:             mu,
 		cond:           sync.NewCond(mu),
+		nextHandle:     1,
 	}
 }
 


### PR DESCRIPTION
This prevents accidentally unsubscribing using an uninitialized handle.  For example:

```
ex := exchange.New()
ex.Subscribe(exchange.Topic("t"), firstListener)
var handle exchange.Handle // Initialized as 0
ex.Unsubscribe(handle) // Unsubscribes firstListener
```

This can also happen when `Subscribe` returns an error and sets a handle to `0`
